### PR TITLE
Build and Release XCFrameworks via Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Build ICU
 on:
+  release:
+    types: [published]
   push:
     branches:
       - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,4 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          product/frameworks/icudata.xcframework
-          product/frameworks/icui18n.xcframework
-          product/frameworks/icuio.xcframework
-          product/frameworks/icuuc.xcframework
+          product/frameworks/*.xcframework.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: Build ICU
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  Build:
+    runs-on: macos-latest
+    timeout-minutes: 120 # Keeps your builds from running too long
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: scripts/build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 120 # Keeps your builds from running too long
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with: 
+        submodules: 'true'
     - name: Build
       run: scripts/build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,3 +14,7 @@ jobs:
         submodules: 'true'
     - name: Build
       run: scripts/build.sh
+    - uses: actions/upload-artifact@v3
+      with:
+        name: product
+        path: product

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,14 +7,21 @@ on:
 jobs:
   Build:
     runs-on: macos-latest
-    timeout-minutes: 120 # Keeps your builds from running too long
+    timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
       with: 
         submodules: 'true'
     - name: Build
-      run: scripts/build.sh
-    - uses: actions/upload-artifact@v3
+      run: |
+        scripts/build.sh
+        for i in product/frameworks/*/; do zip -0 -r "${i%/}.zip" "$i" & done; wait
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: product
-        path: product
+        files: |
+          product/frameworks/icudata.xcframework
+          product/frameworks/icui18n.xcframework
+          product/frameworks/icuio.xcframework
+          product/frameworks/icuuc.xcframework


### PR DESCRIPTION
This workflow builds the frameworks on every push on master.
Upon creating a release or pushing a new tag, it also uploads the xcframework files to the release.

Runner permissions must be elevated to "Read & Write" in the repo settings for this to work correctly.


[Successful run on my fork](https://github.com/Marcocanc/icu4c-iosx/actions/runs/4124637275/jobs/7124920256)
[Github release inlcuding xcframeworks, uploaded by the workflow](https://github.com/Marcocanc/icu4c-iosx/releases/tag/v72)